### PR TITLE
Improve proton path finding logic

### DIFF
--- a/megahack_installer.sh
+++ b/megahack_installer.sh
@@ -64,20 +64,24 @@ steam_path=${steam_path%/}
 echo "Using Steam path: $steam_path"
 
 # find proton version
-if [ -d "${steam_path}/steamapps/common/Proton - Experimental" ]; then proton_dir="${steam_path}/steamapps/common/Proton - Experimental"; fi
-if [ -d "${steam_path}/steamapps/common/Proton 7.0" ]; then proton_dir="${steam_path}/steamapps/common/Proton 7.0"; fi
-if [ -d "${steam_path}/compatibilitytools.d/GE-Proton7-43" ]; then proton_dir="${steam_path}/compatibilitytools.d/GE-Proton7-43"; fi # preferred version; more stable
+config_file="${steam_path}/steamapps/compatdata/322170/config_info"
+proton_dir=$(sed -n '2p' "$config_file") # get second line of config file
+temp_dir="$proton_dir"
+while true; do
+   current_directory=$(dirname "$temp_dir")
+   if [[ "$current_directory" =~ .*/steamapps/common$ ]] || [[ "$current_directory" =~ .*/compatibilitytools.d$ ]]; then
+      proton_dir="$temp_dir"
+      break
+   fi
+   if [[ "$current_directory" == "/" ]] || [[ "$current_directory" == "~/" ]]; then
+      echo "Could not find Proton directory: $proton_dir within config: $config_file"
+      exit 1
+   fi
+   temp_dir="$current_directory"
+done
 
-if [ ! -d "${proton_dir}" ]; then
-   echo "You dont have Proton Experimental, Proton 7.0 or GE-Proton7-43 installed!"
-   echo "Please set Geometry Dash to use either one of those versions (GE preferred)"
-   echo "To do that, go to GD's Steam page, click \"Properties\" > \"Compatibility\", enable \"Force the use of a specific Steam Play compatibility tool\" and select Proton 7.0 or Proton Experimental!"
-   echo "Proton GE has to be installed manually, use Proton 7.0 or Experimental if you are unsure how to do that."
-   echo "You have to start Geometry Dash at least once after changing it for Steam to download the new Proton version."
-   exit 1
-fi
 
-echo "Using ${proton_dir}"
+echo "Using Proton: ${proton_dir}"
 
 # clear temporary files
 rm -rf "/tmp/megahack" 2>/dev/null

--- a/megahack_installer.sh
+++ b/megahack_installer.sh
@@ -65,20 +65,34 @@ echo "Using Steam path: $steam_path"
 
 # find proton version
 config_file="${steam_path}/steamapps/compatdata/322170/config_info"
-proton_dir=$(sed -n '2p' "$config_file") # get second line of config file
-temp_dir="$proton_dir"
-while true; do
-   current_directory=$(dirname "$temp_dir")
-   if [[ "$current_directory" =~ .*/steamapps/common$ ]] || [[ "$current_directory" =~ .*/compatibilitytools.d$ ]]; then
-      proton_dir="$temp_dir"
-      break
-   fi
-   if [[ "$current_directory" == "/" ]] || [[ "$current_directory" == "~/" ]]; then
-      echo "Could not find Proton directory: $proton_dir within config: $config_file"
-      exit 1
-   fi
-   temp_dir="$current_directory"
-done
+found=false
+
+while IFS= read -r line; do
+    temp_dir="$line"
+    declare -A visited_paths
+
+    while [[ "$temp_dir" != "/" ]] && [[ "$temp_dir" != "~/" ]]; do
+        [[ -n ${visited_paths["$temp_dir"]} ]] && break # catch other loops
+        visited_paths["$temp_dir"]=1
+
+        current_directory=$(dirname "$temp_dir")
+        if [[ "$current_directory" =~ .*/steamapps/common$ ]] || [[ "$current_directory" =~ .*/compatibilitytools.d$ ]]; then
+            if [[ -f "$temp_dir/proton" ]]; then
+                proton_dir="$temp_dir"
+                found=true
+                break
+            fi
+        fi
+        temp_dir="$current_directory"
+    done
+done < "$config_file"
+
+if [[ "$found" == true ]]; then
+    echo "Proton directory found: $proton_dir"
+else
+    echo "Could not find Proton directory within config: $config_file"
+    exit 1
+fi
 
 
 echo "Using Proton: ${proton_dir}"


### PR DESCRIPTION
Currently there are two issues with the proton finding logic:
1. If you use a different proton version other than, Proton GE, Proton 7.0 or Proton Experimental, the script fails
2. If you have multiple proton installed it may choose a version other than the one used by the game, This caused the installer to never start for me

This changes the logic to read the config within "${steam_path}/steamapps/compatdata/322170/config_info" and extract the proton path from that