### PR TITLE
Fix some potential errors and clean up the codebase a bit.

### DIFF
--- a/megahack_installer.sh
+++ b/megahack_installer.sh
@@ -75,7 +75,11 @@ fi
 if [ -x "$(command -v fzf)" ]; then
     pushd ~ || cd_fail # we want fzf to use the home directory
 
-    [ "$(command -v fd)" ] && export FZF_DEFAULT_COMMAND="fd --extension=zip" || export FZF_DEFAULT_COMMAND="find . -path '*/.*' -prune -o -iname '*.zip' -print"
+    if [ "$(command -v fd)" ]; then
+        export FZF_DEFAULT_COMMAND="fd --extension=zip"
+    else
+        export FZF_DEFAULT_COMMAND="find . -path '*/.*' -prune -o -iname '*.zip' -print"
+    fi
 
     megahack_zip="$(fzf -e --header="MegaHack Installer.zip selection" --prompt="Please enter the path to your MegaHack .zip file: ")"
     megahack_zip="$(realpath "$megahack_zip")"

--- a/megahack_installer.sh
+++ b/megahack_installer.sh
@@ -109,8 +109,8 @@ if [ ! -d "$possible_path" ]; then
         possible_paths=$(find ~ -path '*/.cache*' -prune -o -name 'steamapps' -print 2>/dev/null)
     fi
 
-    possible_paths=$(printf "${possible_paths}\n" | grep -v 'compatdata\|Program Files (x86)/Steam')
-    possible_path=$(printf "${possible_paths}\n" | head -n1 | sed 's/steamapps//g; s/\/\/$/\//g')
+    possible_paths=$(printf "%s" "${possible_paths}" | grep -v 'compatdata\|Program Files (x86)/Steam')
+    possible_path=$(printf "%s" "${possible_paths}" | head -n1 | sed 's/steamapps//g; s/\/\/$/\//g')
 fi
 
 function prompt_steam_path() {
@@ -121,7 +121,7 @@ function prompt_steam_path() {
 
 steam_path=""
 if [ -n "$possible_path" ]; then
-    printf "Is this your Steam path?: ${possible_path}\n\n"
+    printf "Is this your Steam path?: %s\n\n" "${possible_path}"
     read -p "[Y/n] :" answer
     if [ "${answer,,}" == "y" ] || [ "${answer}" == "" ]; then
         steam_path="$possible_path"
@@ -184,7 +184,7 @@ fi
 megahack_dir=$(ls /tmp/megahack)
 if [ "$DEBUG" == "1" ]; then
     printf "-- contents of /tmp/megahack --\n"
-    printf "$megahack_dir\n"
+    printf "%s\n" "$megahack_dir"
     printf "-- -- -- -- -- - -- -- -- -- --\n"
 fi
 
@@ -193,13 +193,13 @@ megahack_dir="/tmp/megahack/$megahack_dir"
 megahack_dir_contents=$(ls "$megahack_dir")
 
 if [ "$DEBUG" == "1" ]; then
-    printf "MegaHack Directory: $megahack_dir\n"
+    printf "MegaHack Directory: %s\n" "$megahack_dir"
     printf " -- Contents --\n"
-    printf "$megahack_dir_contents\n"
+    printf "%s\n" "$megahack_dir_contents"
     printf " -- -- -- -- --\n"
 fi
 
-megahack_exe=$(printf "$megahack_dir_contents\n" | grep ".exe")
+megahack_exe=$(printf "%s" "$megahack_dir_contents" | grep ".exe")
 
 if [ -z "$megahack_exe" ]; then
     fatal "there's no executable in the provided zip file!"
@@ -212,7 +212,7 @@ printf "\n"
 
 info " - Starting installation process - "
 
-[ "$DEBUG" == "1" ] && printf "cd ${steam_path}/steamapps/compatdata/322170/pfx"
+[ "$DEBUG" == "1" ] && printf "cd %s\n" "${steam_path}/steamapps/compatdata/322170/pfx"
 cd "${steam_path}/steamapps/compatdata/322170/pfx" || cd_fail
 
 info "Starting MegaHack installer ..."
@@ -220,20 +220,20 @@ printf "\n"
 info "To install, press CTRL+V when you are in the exe selection window and click \"Open\""
 
 # copy path to gd exe
-gd_exe_path=$(printf "Z:${steam_path}/steamapps/common/Geometry Dash/GeometryDash.exe\n" | sed 's:/:\\:g')
+gd_exe_path=$(printf "%s" "Z:${steam_path}/steamapps/common/Geometry Dash/GeometryDash.exe" | sed 's:/:\\:g')
 
 info "Path to GD exe: ${gd_exe_path}"
 
 if [ "$XDG_SESSION_TYPE" != "wayland" ]; then
     if [ -x "$(command -v xclip)" ]; then
-		printf "$gd_exe_path\n" | xclip -selection c
+		printf "%s" "$gd_exe_path" | xclip -selection c
     		success "Copied path to clipboard!"
 	else
         warn "xclip is not installed, please copy the path manually"
 	fi
 else
     if [ -x "$(command -v wl-copy)" ]; then
-		printf "$gd_exe_path\n" | wl-copy
+		printf "%s" "$gd_exe_path" | wl-copy
 		success "Copied path to clipboard!"
 	else
         warn "wl-clipboard is not installed, please copy the path manually"
@@ -253,7 +253,7 @@ fi
 
 if [ "$DEBUG" == "1" ]; then
     printf "Starting MegaHack:\n"
-    printf "STEAM_COMPAT_DATA_PATH=\"${steam_path}/steamapps/compatdata/322170\" WINEPREFIX=\"$PWD\" \"${proton_dir}/proton\" runinprefix \"${megahack_dir}/${megahack_exe}\"\n"
+    printf "STEAM_COMPAT_DATA_PATH=\"%s\" WINEPREFIX=\"%s\" \"%s\" runinprefix \"%s\"\n" "${steam_path}/steamapps/compatdata/322170" "$PWD" "${proton_dir}/proton" "${megahack_dir}/${megahack_exe}"
 fi
 
 STEAM_COMPAT_DATA_PATH="${steam_path}/steamapps/compatdata/322170" WINEPREFIX="$PWD" "${proton_dir}/proton" runinprefix "${megahack_dir}/${megahack_exe}"


### PR DESCRIPTION
This pull request improves the script a little bit. Changes:

- Use command -v to check whether a binary is available on the user's system, rather than hash which emits warnings if false.
- Replace all instances of echo with printf, because echo isn't identical on every system. Notably, Gentoo interprets the -e argument as text and as such prints it. In my opinion, echo shouldn't be used in shell scripts.
- Check for the presence of wget on the system. Some distros don't ship wget by default, so in that case we should fail. Ideally a curl fallback would be added but I haven't done that.
- Simplify/improve some code here and there.